### PR TITLE
add block_analysis.ts

### DIFF
--- a/scripts/block_analysis.ts
+++ b/scripts/block_analysis.ts
@@ -1,0 +1,22 @@
+const getLastBlocks = async (n) => {
+  let last = await ethers.provider.getBlock();
+  let tLast = last.timestamp;
+  let totalTxn = 0;
+  let gasUsageSum = 0;
+  let b;
+  for (let i = 0; i < n; i++) {
+    b = await ethers.provider.getBlock(last.number - i);
+    totalTxn += b.transactions.length;
+    console.log(`number: ${b.number}, miner: ${b.miner}, gasUsed: ${b.gasUsed}, gasUsed/gasLimit: ${b.gasUsed / b.gasLimit}, txs: ${b.transactions.length}`);
+    gasUsageSum += b.gasUsed / b.gasLimit;
+  }
+  let t0 = b.timestamp;
+  let diff = tLast - t0;
+  let avgTps = totalTxn / diff;
+  let avgGasUsage = gasUsageSum / n;
+  console.log(`total tx: ${totalTxn}`);
+  console.log(`average TPS: ${avgTps}`);
+  console.log(`average gas usage: ${avgGasUsage}`);
+};
+
+getLastBlocks(100);


### PR DESCRIPTION
sometimes it can be useful to analyze blocks from a new terminal

this script will give insights e.g.:
```
$ npx hardhat run scripts/block_analysis.ts --network local
number: 57278, miner: 0x1687736326c9fea17e25fC5287613693c912909C, gasUsed: 11139050, gasUsed/gasLimit: 0.7426033333333333, txs: 325
number: 57277, miner: 0x15fdd31C61141abd04A99FD6822c8558854ccDe3, gasUsed: 9870912, gasUsed/gasLimit: 0.6580608, txs: 288
number: 57276, miner: 0x1D5404Bd9DA88E0204360A1A9AB8b87c66C1Bc2f, gasUsed: 11378968, gasUsed/gasLimit: 0.7585978666666666, txs: 332
number: 57275, miner: 0x5C6974C9ea841Be688864633dC9ca8a357843eeA, gasUsed: 10316474, gasUsed/gasLimit: 0.6877649333333333, txs: 301
number: 57274, miner: 0x1687736326c9fea17e25fC5287613693c912909C, gasUsed: 10693488, gasUsed/gasLimit: 0.7128992, txs: 312
number: 57273, miner: 0x15fdd31C61141abd04A99FD6822c8558854ccDe3, gasUsed: 9870912, gasUsed/gasLimit: 0.6580608, txs: 288
number: 57272, miner: 0x1D5404Bd9DA88E0204360A1A9AB8b87c66C1Bc2f, gasUsed: 10350748, gasUsed/gasLimit: 0.6900498666666667, txs: 302
number: 57271, miner: 0x5C6974C9ea841Be688864633dC9ca8a357843eeA, gasUsed: 9562446, gasUsed/gasLimit: 0.6374964, txs: 279
number: 57270, miner: 0x1687736326c9fea17e25fC5287613693c912909C, gasUsed: 10316474, gasUsed/gasLimit: 0.6877649333333333, txs: 301
number: 57269, miner: 0x15fdd31C61141abd04A99FD6822c8558854ccDe3, gasUsed: 8739870, gasUsed/gasLimit: 0.582658, txs: 255
number: 57268, miner: 0x1D5404Bd9DA88E0204360A1A9AB8b87c66C1Bc2f, gasUsed: 8842692, gasUsed/gasLimit: 0.5895128, txs: 258
number: 57267, miner: 0x5C6974C9ea841Be688864633dC9ca8a357843eeA, gasUsed: 8534226, gasUsed/gasLimit: 0.5689484, txs: 249
...
total tx: 23258
average TPS: 19.381666666666668
average gas usage: 0.5356879286666667
```